### PR TITLE
Fix exception: TypeError: can't concat bytes to str

### DIFF
--- a/pyicap.py
+++ b/pyicap.py
@@ -264,7 +264,7 @@ class BaseICAPRequestHandler(StreamRequestHandler):
     def set_icap_response(self, code, message=None):
         """Sets the ICAP response's status line and response code"""
         self.icap_response = b'ICAP/1.0 ' + str(code).encode('utf-8') + b' ' + \
-            (message if message else self._responses[code][0])
+            (str.encode(message) if message else self._responses[code][0])
         self.icap_response_code = code
 
     def set_icap_header(self, header, value):


### PR DESCRIPTION
Found when studying issue #24

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/socketserver.py", line 639, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.6/socketserver.py", line 696, in __init__
    self.handle()
  File "./pyicap.py", line 443, in handle
    self.handle_one_request()
  File "./pyicap.py", line 500, in handle_one_request
    self.send_error(e.code, e.message[0])
  File "./pyicap.py", line 525, in send_error
    self.set_icap_response(code, message=message)
  File "./pyicap.py", line 267, in set_icap_response
    (message if message else self._responses[code][0])
TypeError: can't concat bytes to str
----------------------------------------
```