### PR TITLE
Fix encoding error

### DIFF
--- a/pyicap.py
+++ b/pyicap.py
@@ -350,7 +350,7 @@ class BaseICAPRequestHandler(StreamRequestHandler):
         icap_header_str = b''
         for k in self.icap_headers:
             for v in self.icap_headers[k]:
-                icap_header_str += k + b': ' + v + b'\r\n'
+                icap_header_str += "{}:{}\r\n".format(k, v).encode()
                 if k.lower() == b'connection' and v.lower() == b'close':
                     self.close_connection = True
                 if k.lower() == b'connection' and v.lower() == b'keep-alive':


### PR DESCRIPTION
When using this package as a server with squid, i was getting the following error;
```
Exception happened during processing of request from ('127.0.0.1', 58936)
Traceback (most recent call last):
  File "/usr/lib/python3.8/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.8/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/local/lib/python3.8/dist-packages/pyicap.py", line 442, in handle
    self.handle_one_request()
  File "/usr/local/lib/python3.8/dist-packages/pyicap.py", line 492, in handle_one_request
    method()
  File "server.py", line 18, in request_OPTIONS
    self.send_headers(False)
  File "/usr/local/lib/python3.8/dist-packages/pyicap.py", line 325, in send_headers
    icap_header_str += k + b': ' + v + b'\r\n'
TypeError: can only concatenate str (not "bytes") to str
```

Where the squid config file contains:
```
icap_enable          on
icap_preview_enable  on
icap_preview_size    128
icap_send_client_ip  on

icap_service service_req reqmod_precache icap://127.0.0.1:13440/request
adaptation_access service_req allow all
```

This PR fixes the issue.
