### PR TITLE
Fix example code in README.md - use bytes instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ class ICAPHandler(BaseICAPRequestHandler):
 
     def echo_OPTIONS(self):
         self.set_icap_response(200)
-        self.set_icap_header('Methods', 'RESPMOD')
-        self.set_icap_header('Preview', '0')
+        self.set_icap_header(b'Methods', b'RESPMOD')
+        self.set_icap_header(b'Preview', b'0')
         self.send_headers(False)
 
     def echo_RESPMOD(self):


### PR DESCRIPTION
Examples in /examples all use bytes, but the example code in README.md uses str.

This changes the README.md example to use bytes as well.

This is also related to #40. Using bytes would give the caller more control over the headers, but I'm not sure if such control is ever needed by the caller.